### PR TITLE
Update Dockerfile and DOCKER-USAGE.md

### DIFF
--- a/DOCKER-USAGE.md
+++ b/DOCKER-USAGE.md
@@ -1,12 +1,7 @@
-# Using Dockerfile
+# Usage
 
-## Usage
+Build the container:
+`docker build -t uboot-nx .`
 
-```sh
-docker run --rm -it -e DISTRO=ubuntu -v "$PWD":/out alizkan/switch-uboot:linux-norebase
-```
-
-You can override the workdir used in the docker, to use your own changes, without rebuilding the image by adding this repository directory as a volume to the docker command above.
-```sh
--v $(pwd):build/
-```
+Run the container:
+`docker run --rm -it -v $(pwd):/out uboot-nx`

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,12 @@ RUN /bin/ash -c 'set -ex && \
        apt install -y gcc-aarch64-linux-gnu; \
     fi'
 
-ARG DISTRO
-ENV DISTRO=${DISTRO}
 ENV ARCH=arm64
 ENV CROSS_COMPILE=aarch64-linux-gnu-
 
-WORKDIR /build
-COPY . /build
+WORKDIR /out
 VOLUME /out
 
-CMD sed -i 's/boot_prefixes=\/ \/switchroot\/.*\/\\0/boot_prefixes=\/ \/switchroot\/'${DISTRO}'\/\\0/' /build/include/config_distro_bootcmd.h && make nintendo-switch_defconfig && make && cp u-boot.elf /out
+CMD make nintendo-switch_defconfig && \
+    make -j$(nproc) && \
+    cp u-boot.bin bl33.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV CROSS_COMPILE=aarch64-linux-gnu-
 WORKDIR /out
 VOLUME /out
 
-CMD make nintendo-switch_defconfig && \
+CMD make prepare && \
+    make nintendo-switch_defconfig && \
     make -j$(nproc) && \
     cp u-boot.bin bl33.bin


### PR DESCRIPTION
The current Dockerfile and DOCKER-USAGE.md are making assumption that don't stand anymore in the current setup.
Update them for a cleaner and likely always buildable setup.